### PR TITLE
Delete config_protocol.py

### DIFF
--- a/adapter_partial/config_protocol.py
+++ b/adapter_partial/config_protocol.py
@@ -1,6 +1,0 @@
-from typing import Any, Protocol
-
-
-class Config(Protocol):
-    def get(self, key: str, default: Any = None) -> Any | None:
-        ...


### PR DESCRIPTION
The Config class is not required anymore when using the partial function solution.